### PR TITLE
Implement delete account API

### DIFF
--- a/internal/app/api/accounts.go
+++ b/internal/app/api/accounts.go
@@ -115,3 +115,34 @@ func (app *application) updateAccountHandler(w http.ResponseWriter, r *http.Requ
 		app.httpUtil.ServerErrorResponse(w, r, err)
 	}
 }
+
+func (app *application) deleteAccountHandler(w http.ResponseWriter, r *http.Request) {
+	id, err := app.httpUtil.ReadIDParam(r)
+	if err != nil {
+		app.httpUtil.NotFoundResponse(w, r)
+		return
+	}
+
+	var req service.DeleteAccountRequest
+
+	req.ID = *id
+	req.UserID = httputil.ContextGetUserID(r)
+
+	err = app.services.Accounts.Delete(&req)
+	if err != nil {
+		switch {
+		case errors.Is(err, domain.ErrRecordNotFound):
+			app.httpUtil.NotFoundResponse(w, r)
+		case errors.Is(err, domain.ErrUserNotAllowed):
+			app.httpUtil.UserNotAllowedResponse(w, r)
+		default:
+			app.httpUtil.ServerErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	err = app.httpUtil.WriteJSON(w, httputil.StatusDeleteSuccess, nil, nil, nil)
+	if err != nil {
+		app.httpUtil.ServerErrorResponse(w, r, err)
+	}
+}

--- a/internal/app/api/routes.go
+++ b/internal/app/api/routes.go
@@ -17,6 +17,7 @@ func (app *application) routes() http.Handler {
 	router.Handle("GET /api/v1/accounts", m.RequireActivatedUser(app.listAccountsHandler))
 	router.Handle("POST /api/v1/accounts", m.RequireActivatedUser(app.addAccountHandler))
 	router.Handle("PATCH /api/v1/accounts/{id}", m.RequireActivatedUser(app.updateAccountHandler))
+	router.Handle("DELETE /api/v1/accounts/{id}", m.RequireActivatedUser(app.deleteAccountHandler))
 
 	return m.RecoverPanic(m.EnableCORS(m.RequestLogger(m.Authenticate(router))))
 }

--- a/internal/httputil/response.go
+++ b/internal/httputil/response.go
@@ -31,9 +31,10 @@ func NewStatus(httpStatus int, code, message string) Status {
 
 var (
 	// 2xx
-	StatusSuccess  = NewStatus(http.StatusOK, "200000", "Success")
-	StatusCreated  = NewStatus(http.StatusCreated, "201000", "Resource successfully created")
-	StatusAccepted = NewStatus(http.StatusAccepted, "202000", "Request accepted and is being processed")
+	StatusSuccess       = NewStatus(http.StatusOK, "200000", "Success")
+	StatusDeleteSuccess = NewStatus(http.StatusOK, "200001", "Resource successfully deleted")
+	StatusCreated       = NewStatus(http.StatusCreated, "201000", "Resource successfully created")
+	StatusAccepted      = NewStatus(http.StatusAccepted, "202000", "Request accepted and is being processed")
 
 	// 4xx
 	StatusBadRequest                = NewStatus(http.StatusBadRequest, "400000", "Bad request")

--- a/internal/repository/accounts.go
+++ b/internal/repository/accounts.go
@@ -179,3 +179,28 @@ func (r *AccountRepository) Update(account *domain.Account) error {
 
 	return nil
 }
+
+func (r *AccountRepository) Delete(id uuid.UUID) error {
+	query := `
+		DELETE FROM accounts
+		WHERE id = $1`
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	result, err := r.DB.ExecContext(ctx, query, id)
+	if err != nil {
+		return err
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rowsAffected == 0 {
+		return domain.ErrRecordNotFound
+	}
+
+	return nil
+}

--- a/internal/service/accounts.go
+++ b/internal/service/accounts.go
@@ -110,3 +110,21 @@ func (s *AccountService) Update(req *UpdateAccountRequest) (*AccountResponse, er
 
 	return res, nil
 }
+
+func (s *AccountService) Delete(req *DeleteAccountRequest) error {
+	account, err := s.accountRepo.GetByID(req.ID)
+	if err != nil {
+		return err
+	}
+
+	if req.UserID != account.UserID {
+		return domain.ErrUserNotAllowed
+	}
+
+	err = s.accountRepo.Delete(account.ID)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/internal/service/request.go
+++ b/internal/service/request.go
@@ -100,6 +100,11 @@ func ValidateUpdateAccountReq(v *validator.Validator, req *UpdateAccountRequest)
 	}
 }
 
+type DeleteAccountRequest struct {
+	ID     uuid.UUID `json:"-"`
+	UserID uuid.UUID `json:"-"`
+}
+
 func ValidateFilters(v *validator.Validator, f domain.Filters) {
 	v.Check(f.Limit > 0, "limit", "limit must be greater than zero")
 	v.Check(f.Limit <= 100, "limit", "limit must be a maximum of 100")


### PR DESCRIPTION
This PR is created to fulfill the functional requirement **FR2-4**.

> **FR2-4**: As a user, I want to delete a financial account that I no longer use so that my account list stays relevant.