### PR TITLE
Implement delete transaction API

### DIFF
--- a/internal/app/api/routes.go
+++ b/internal/app/api/routes.go
@@ -21,6 +21,7 @@ func (app *application) routes() http.Handler {
 
 	router.Handle("POST /api/v1/transactions", m.RequireActivatedUser(app.addTransactionHandler))
 	router.Handle("PATCH /api/v1/transactions/{id}", m.RequireActivatedUser(app.updateTransactionHandler))
+	router.Handle("DELETE /api/v1/transactions/{id}", m.RequireActivatedUser(app.deleteTransactionHandler))
 
 	return m.RecoverPanic(m.EnableCORS(m.RequestLogger(m.Authenticate(router))))
 }

--- a/internal/app/api/transactions.go
+++ b/internal/app/api/transactions.go
@@ -92,3 +92,34 @@ func (app *application) updateTransactionHandler(w http.ResponseWriter, r *http.
 		app.httpUtil.ServerErrorResponse(w, r, err)
 	}
 }
+
+func (app *application) deleteTransactionHandler(w http.ResponseWriter, r *http.Request) {
+	id, err := app.httpUtil.ReadIDParam(r)
+	if err != nil {
+		app.httpUtil.NotFoundResponse(w, r)
+		return
+	}
+
+	var req service.DeleteTransactionRequest
+
+	req.ID = *id
+	req.UserID = httputil.ContextGetUserID(r)
+
+	err = app.services.Transactions.Delete(&req)
+	if err != nil {
+		switch {
+		case errors.Is(err, domain.ErrRecordNotFound):
+			app.httpUtil.NotFoundResponse(w, r)
+		case errors.Is(err, domain.ErrUserNotAllowed):
+			app.httpUtil.UserNotAllowedResponse(w, r)
+		default:
+			app.httpUtil.ServerErrorResponse(w, r, err)
+		}
+		return
+	}
+
+	err = app.httpUtil.WriteJSON(w, httputil.StatusDeleteSuccess, nil, nil, nil)
+	if err != nil {
+		app.httpUtil.ServerErrorResponse(w, r, err)
+	}
+}

--- a/internal/repository/transactions.go
+++ b/internal/repository/transactions.go
@@ -88,6 +88,45 @@ func (r *TransactionRepository) GetByID(id uuid.UUID) (*domain.Transaction, erro
 	return &transaction, nil
 }
 
+func (r *TransactionRepository) GetByIDForUpdate(id uuid.UUID) (*domain.Transaction, error) {
+	query := `
+		SELECT id, user_id, type, category_id, amount, date, title, notes, from_account_id, to_account_id, created_at, updated_at, version
+		FROM transactions
+		WHERE id = $1
+		FOR UPDATE`
+
+	var transaction domain.Transaction
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	err := r.DB.QueryRowContext(ctx, query, id).Scan(
+		&transaction.ID,
+		&transaction.UserID,
+		&transaction.Type,
+		&transaction.CategoryID,
+		&transaction.Amount,
+		&transaction.Date,
+		&transaction.Title,
+		&transaction.Notes,
+		&transaction.FromAccountID,
+		&transaction.ToAccountID,
+		&transaction.CreatedAt,
+		&transaction.UpdatedAt,
+		&transaction.Version,
+	)
+	if err != nil {
+		switch {
+		case errors.Is(err, sql.ErrNoRows):
+			return nil, domain.ErrRecordNotFound
+		default:
+			return nil, err
+		}
+	}
+
+	return &transaction, nil
+}
+
 func (r *TransactionRepository) Update(transaction *domain.Transaction) error {
 	query := `
 		UPDATE transactions
@@ -120,6 +159,31 @@ func (r *TransactionRepository) Update(transaction *domain.Transaction) error {
 		default:
 			return err
 		}
+	}
+
+	return nil
+}
+
+func (r *TransactionRepository) Delete(id uuid.UUID) error {
+	query := `
+		DELETE FROM transactions
+		WHERE id = $1`
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	result, err := r.DB.ExecContext(ctx, query, id)
+	if err != nil {
+		return err
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+
+	if rowsAffected == 0 {
+		return domain.ErrRecordNotFound
 	}
 
 	return nil

--- a/internal/service/request.go
+++ b/internal/service/request.go
@@ -253,3 +253,8 @@ func ApplyTransactionUpdates(transaction *domain.Transaction, req *UpdateTransac
 		transaction.SetToAccountID(req.ToAccountID)
 	}
 }
+
+type DeleteTransactionRequest struct {
+	ID     uuid.UUID `json:"-"`
+	UserID uuid.UUID `json:"-"`
+}

--- a/internal/service/transactions.go
+++ b/internal/service/transactions.go
@@ -232,6 +232,33 @@ func (s *TransactionService) Update(req *UpdateTransactionRequest, v *validator.
 	return res, nil
 }
 
+func (s *TransactionService) Delete(req *DeleteTransactionRequest) error {
+	err := s.TxProvider.WithTx(func(adapters repository.Adapters) error {
+		transaction, err := adapters.TransactionRepo.GetByIDForUpdate(req.ID)
+		if err != nil {
+			return err
+		}
+
+		if transaction.UserID != req.UserID {
+			return domain.ErrUserNotAllowed
+		}
+
+		err = s.revertAccountBalances(adapters, transaction.Type, transaction.Amount, transaction.GetFromAccountID(), transaction.GetToAccountID())
+		if err != nil {
+			return err
+		}
+
+		err = adapters.TransactionRepo.Delete(transaction.ID)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	})
+
+	return err
+}
+
 func (s *TransactionService) updateAccountBalances(adapters repository.Adapters, transaction *domain.Transaction) error {
 	switch transaction.Type {
 	case domain.TransactionTypeExpense:


### PR DESCRIPTION
This PR is created to fulfill the functional requirement **FR4-8** and **FR4-9**.

> **FR4-8**: As a user, I want to delete a transaction, so that I can remove erroneous entries.

> **FR4-9**: As a user, when I create, modify, or delete a transaction, I want account balances to automatically update, so that my financial data stays accurate.